### PR TITLE
Updated cloudbuild.yaml for docker fix and for cacheing

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -75,4 +75,3 @@ steps:
     volumes:
     - name: user.home
       path: /root
-

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,17 +1,78 @@
+substitutions:
+  _GCS_CACHE_BUCKET: ceres-cache
+  _CERES_PROJECT: ceres-rollup-service
+
 steps:
-  - name: 'gcr.io/cloud-builders/mvn'
-    id: DEPLOY
-    args: ['-Ddocker.image.prefix=gcr.io/ceres-dev-222017', 'package', 'jib:dockerBuild']
 
-# Tagging the image for a more specific image can be used
-  - name: 'gcr.io/cloud-builders/docker'
-    id: TAG_IMAGE_WITH_BRANCH_NAME
-    args: ['tag', 'gcr.io/ceres-dev-222017/metrics-ingestion-service:latest', 'gcr.io/ceres-dev-222017/metrics-ingestion-service:$BRANCH_NAME']
-  - name: 'gcr.io/cloud-builders/docker'
-    id: TAG_IMAGE_WITH_SHORT_SHA
-    args: ['tag', 'gcr.io/ceres-dev-222017/metrics-ingestion-service:latest', 'gcr.io/ceres-dev-222017/metrics-ingestion-service:$SHORT_SHA']
+    # This is ugly because of
+    # https://github.com/GoogleContainerTools/jib/issues/1500#issuecomment-466207421
+  - id: FIX_DOCKER
+    name: gcr.io/cloud-builders/mvn
+    waitFor: ['-']
+    dir: /root
+    entrypoint: bash
+    args:
+    - -c
+    - # Links the Docker config to /root/.docker/config.json so that Jib picks it up.
+      # Note that this is only a temporary workaround.
+      # See https://github.com/GoogleContainerTools/jib/pull/1479.
+      |
+      mkdir .docker &&
+      ln -vs $$HOME/.docker/config.json .docker/config.json
+    volumes:
+    - name: user.home
+      path: /root
 
-images:
-  - 'gcr.io/ceres-dev-222017/metrics-ingestion-service'
-  - 'gcr.io/ceres-dev-222017/metrics-ingestion-service:$BRANCH_NAME'
-  - 'gcr.io/ceres-dev-222017/metrics-ingestion-service:$SHORT_SHA'
+  # Load the cached files from GCS if they exist.
+  - id: PULL_DOWN_CACHE
+    waitFor: ['-']
+    name: gcr.io/cloud-builders/gsutil
+    dir: /root
+    entrypoint: bash
+    args:
+    - -c
+    - |
+      (
+        gsutil cp gs://${_GCS_CACHE_BUCKET}/${_CERES_PROJECT}-m2-cache.tar.gz /tmp/m2-cache.tar.gz &&
+        tar -xzf /tmp/m2-cache.tar.gz
+      ) || echo 'Cache not found'
+    volumes:
+    - name: user.home
+      path: /root
+
+  - id: PACKAGE_AND_PUSH_CONTAINER
+    name: 'gcr.io/cloud-builders/mvn'
+    env:
+    - 'SHORT_SHA=$SHORT_SHA'
+    - 'BRANCH_NAME=$BRANCH_NAME'
+    args:
+    - compile
+    # Runs the Jib build by using the latest version of the plugin.
+    # To use a specific version, configure the plugin in the pom.xml.
+    - jib:build
+    # Skip Tests since it happened in the previous test
+    - "-Dmaven.test.skip=true"
+    # Ensure we name the image correctly since its not in pom.xml
+    - "-Ddocker.image.prefix=gcr.io/$PROJECT_ID"
+    volumes:
+    - name: user.home
+      path: /root
+
+  # Saves the files to the GCS cache.
+  - id: PUSH_UP_CACHE
+    waitFor:
+    - PACKAGE_AND_PUSH_CONTAINER
+    name: gcr.io/cloud-builders/gsutil
+    dir: /root
+    entrypoint: bash
+    # Caches the local Maven repository.
+    args:
+    - -c
+    - |
+      set -ex
+      tar -czf /tmp/m2-cache.tar.gz .m2 &&
+      gsutil cp /tmp/m2-cache.tar.gz gs://${_GCS_CACHE_BUCKET}/${_CERES_PROJECT}-m2-cache.tar.gz
+    volumes:
+    - name: user.home
+      path: /root
+

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -40,6 +40,8 @@ steps:
     - name: user.home
       path: /root
 
+  # This phase is when the tests are run, the app is packaged into a container,
+  # and its pushed to the Google Container Registry
   - id: PACKAGE_AND_PUSH_CONTAINER
     name: 'gcr.io/cloud-builders/mvn'
     env:

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,11 @@
                 <configuration>
                     <to>
                         <image>${docker.image.prefix}/metrics-rollup-service</image>
+                        <tags>
+                          <tag>${project.version}</tag>
+                          <tag>${env.SHORT_SHA}</tag>
+                          <tag>${env.BRANCH_NAME}</tag>
+                        </tags>
                     </to>
                 </configuration>
             </plugin>


### PR DESCRIPTION
# Resolves

This makes big changes to the cloudbuild.yaml file for multiple reasons.

1. There is an issue with the maven cloudbuild image put out by Google. This does the needful to allow for docker daemon access. [GoogleContainerTools/jib/issues/1500](https://github.com/GoogleContainerTools/jib/issues/1500)
2. This adds caching to speed up build times.
3. This edits the pom.xml to allow for more tagging options on containers. The more tags help with deployments and with rollbacks, if needed.